### PR TITLE
Uncheck common errors when uploading entire folder

### DIFF
--- a/main.go
+++ b/main.go
@@ -356,7 +356,16 @@ func uploadFilesInDirectory(httpClient *rest.Client, sourcePath string, destDir 
 				return err
 			}
 		} else {
-			uploadFile(httpClient, fullPath, strings.ReplaceAll(destDir, "\\", "/"), partSize, numWorkers)
+			err := uploadFile(httpClient, fullPath, strings.ReplaceAll(destDir, "\\", "/"), partSize, numWorkers)
+			if err != nil {
+				channelInvalidError := "CHANNEL_INVALID"
+				fileExistsError := "file exists"
+				if strings.Contains(err.Error(), channelInvalidError) || strings.Contains(err.Error(), fileExistsError) {
+					fmt.Println("Error uploading file: ", err)
+					return nil
+				}
+				return err
+			}
 		}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -356,10 +356,7 @@ func uploadFilesInDirectory(httpClient *rest.Client, sourcePath string, destDir 
 				return err
 			}
 		} else {
-			err := uploadFile(httpClient, fullPath, strings.ReplaceAll(destDir, "\\", "/"), partSize, numWorkers)
-			if err != nil {
-				return err
-			}
+			uploadFile(httpClient, fullPath, strings.ReplaceAll(destDir, "\\", "/"), partSize, numWorkers)
 		}
 	}
 	return nil


### PR DESCRIPTION
Hi. As mentioned in #6, when we attempt to upload an entire folder and an error occurs, it currently halts the entire process. Therefore, I've modified the code to remove the check only for the most common errors that I've seen returned by the `uploadFile` function, which are `CHANNEL_INVALID` and `file exists`.