### PR TITLE
Support for Channel ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Build and Release
+name: Goreleaser
 
 on:
   push:
-    branches:
-      - 'main'
+    tags:
+      - "*"
 
 permissions:
   contents: write
@@ -12,34 +12,14 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-
-      - name: Configure Git
-        run: |
-          git config --global user.email "hackmonker127001@protonmail.com"
-          git config --global user.name "hackmonker"      
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.21
-
-      - name: Create Tag
-        id: tag
-        run: |
-          # See https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
-          TAG=v$(date -Iseconds | sed 's/[T:\+]/-/g')
-          echo "$TAG"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          git tag -a $TAG -m "Published version $TAG" ${GITHUB_SHA}
-          git push origin $TAG
-        env:
-            GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -47,4 +27,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Goreleaser
+name: Build and Release
 
 on:
   push:
-    tags:
-      - "*"
+    branches:
+      - 'main'
 
 permissions:
   contents: write
@@ -12,19 +12,36 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "hackmonker127001@protonmail.com"
+          git config --global user.name "hackmonker"      
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.21
+
+      - name: Create Tag
+        id: tag
+        run: |
+          # See https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
+          TAG=v$(date -Iseconds | sed 's/[T:\+]/-/g')
+          echo "$TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          git tag -a $TAG -m "Published version $TAG" ${GITHUB_SHA}
+          git push origin $TAG
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -53,13 +53,13 @@ type Part struct {
 
 // Add a new field for Telegram channel ID in the FilePayload struct
 type FilePayload struct {
-    Name      string `json:"name"`
-    Type      string `json:"type"`
-    Parts     []Part `json:"parts,omitempty"`
-    MimeType  string `json:"mimeType"`
-    Path      string `json:"path"`
-    Size      int64  `json:"size"`
-    ChannelID int64  `json:"channelId"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Parts     []Part `json:"parts,omitempty"`
+	MimeType  string `json:"mimeType"`
+	Path      string `json:"path"`
+	Size      int64  `json:"size"`
+	ChannelID int64  `json:"channelId"`
 }
 
 type CreateDirRequest struct {
@@ -277,18 +277,18 @@ func uploadFile(httpClient *rest.Client, filePath string, destDir string, partSi
 		return parts[i].PartNo < parts[j].PartNo
 	})
 
-    filePayload := FilePayload{
-        Name:      fileName,
-        Type:      "file",
-        Parts:     parts,
-        MimeType:  mimeType,
-        Path:      destDir,
-        Size:      fileSize,
-        ChannelID: channelID, // Set the Telegram channel ID
-    }
+	filePayload := FilePayload{
+		Name:      fileName,
+		Type:      "file",
+		Parts:     parts,
+		MimeType:  mimeType,
+		Path:      destDir,
+		Size:      fileSize,
+		ChannelID: channelID, // Set the Telegram channel ID
+	}
 
-	json.Marshal(filePayload)
-
+	// Marshal the filePayload to JSON
+	payloadJSON, err := json.Marshal(filePayload)
 	if err != nil {
 		fmt.Println("Error marshaling JSON:", err)
 		return err
@@ -299,7 +299,7 @@ func uploadFile(httpClient *rest.Client, filePath string, destDir string, partSi
 		Path:   "/api/files",
 	}
 
-	resp, err := httpClient.CallJSON(context.TODO(), &opts, &filePayload, nil)
+	resp, err := httpClient.CallJSON(context.TODO(), &opts, payloadJSON, nil)
 
 	if resp.StatusCode != 200 {
 		fmt.Println("Request failed with status code:", resp.StatusCode)
@@ -354,12 +354,12 @@ func uploadFilesInDirectory(httpClient *rest.Client, sourcePath string, destDir 
 			if err != nil {
 				return err
 			}
-			err = uploadFilesInDirectory(httpClient, fullPath, subDir, partSize, numWorkers)
+			err = uploadFilesInDirectory(httpClient, fullPath, subDir, partSize, numWorkers, channelID) // Pass the channel ID
 			if err != nil {
 				return err
 			}
 		} else {
-			err := uploadFile(httpClient, fullPath, strings.ReplaceAll(destDir, "\\", "/"), partSize, numWorkers)
+			err := uploadFile(httpClient, fullPath, strings.ReplaceAll(destDir, "\\", "/"), partSize, numWorkers, channelID) // Pass the channel ID
 			if err != nil {
 				return err
 			}
@@ -369,53 +369,53 @@ func uploadFilesInDirectory(httpClient *rest.Client, sourcePath string, destDir 
 }
 
 func main() {
-    sourcePath := flag.String("path", "", "File or directory path to upload")
-    destDir := flag.String("dest", "", "Remote directory for uploaded files")
+	sourcePath := flag.String("path", "", "File or directory path to upload")
+	destDir := flag.String("dest", "", "Remote directory for uploaded files")
 	channelID := flag.Int64("channelID", 0, "Telegram channel ID") // Use a pointer to int64
 
 	flag.Parse()
-	
+
 	if *sourcePath == "" || *destDir == "" || *channelID == 0 { // Check if channelID is provided
 		fmt.Println("Usage: ./uploader -path <file_or_directory_path> -dest <remote_directory> -channelID <telegram_channel_id>")
 		return
 	}
 
-    config, err := loadConfigFromEnv()
+	config, err := loadConfigFromEnv()
 
-    if err != nil {
-        fmt.Println("Error:", err)
-        return
-    }
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
 
-    authCookie := &http.Cookie{
-        Name:  "user-session",
-        Value: config.SessionToken,
-    }
+	authCookie := &http.Cookie{
+		Name:  "user-session",
+		Value: config.SessionToken,
+	}
 
-    httpClient := rest.NewClient(http.DefaultClient).SetRoot(config.ApiURL).SetCookie(authCookie)
+	httpClient := rest.NewClient(http.DefaultClient).SetRoot(config.ApiURL).SetCookie(authCookie)
 
-    err = createRemoteDir(httpClient, *destDir)
+	err = createRemoteDir(httpClient, *destDir)
 
-    if err != nil {
-        fmt.Println("Error:", err)
-        return
-    }
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
 
-    if fileInfo, err := os.Stat(*sourcePath); err == nil {
-        if fileInfo.IsDir() {
-            err := uploadFilesInDirectory(httpClient, *sourcePath, *destDir, config.PartSize, config.Workers, *channelID) // Pass the channel ID
-            if err != nil {
-                fmt.Println("Error uploading files:", err)
-            }
-        } else {
-            if err := uploadFile(httpClient, *sourcePath, *destDir, config.PartSize, config.Workers, *channelID); // Pass the channel ID
-                err != nil {
-                fmt.Println("Error uploading file:", err)
-            }
-        }
-    } else {
-        fmt.Println("Error:", err)
-    }
+	if fileInfo, err := os.Stat(*sourcePath); err == nil {
+		if fileInfo.IsDir() {
+			err := uploadFilesInDirectory(httpClient, *sourcePath, *destDir, config.PartSize, config.Workers, *channelID) // Pass the channel ID
+			if err != nil {
+				fmt.Println("Error uploading files:", err)
+			}
+		} else {
+			if err := uploadFile(httpClient, *sourcePath, *destDir, config.PartSize, config.Workers, *channelID); // Pass the channel ID
+				err != nil {
+				fmt.Println("Error uploading file:", err)
+			}
+		}
+	} else {
+		fmt.Println("Error:", err)
+	}
 
-    fmt.Println("Uploads complete!")
+	fmt.Println("Uploads complete!")
 }

--- a/main.go
+++ b/main.go
@@ -338,7 +338,7 @@ func createRemoteDir(httpClient *rest.Client, path string) error {
 	return nil
 }
 
-func uploadFilesInDirectory(httpClient *rest.Client, sourcePath string, destDir string, partSize int64, numWorkers int) error {
+func uploadFilesInDirectory(httpClient *rest.Client, sourcePath string, destDir string, partSize int64, numWorkers int, channelID int64) error {
 	entries, err := os.ReadDir(sourcePath)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -371,13 +371,14 @@ func uploadFilesInDirectory(httpClient *rest.Client, sourcePath string, destDir 
 func main() {
     sourcePath := flag.String("path", "", "File or directory path to upload")
     destDir := flag.String("dest", "", "Remote directory for uploaded files")
-    channelID := flag.Int64("channelID", 0, "Telegram channel ID") // Add a new flag for channel ID
-    flag.Parse()
+	channelID := flag.Int64("channelID", 0, "Telegram channel ID") // Use a pointer to int64
 
-    if *sourcePath == "" || *destDir == "" || *channelID == 0 {
-        fmt.Println("Usage: ./uploader -path <file_or_directory_path> -dest <remote_directory> -channelID <telegram_channel_id>")
-        return
-    }
+	flag.Parse()
+	
+	if *sourcePath == "" || *destDir == "" || *channelID == 0 { // Check if channelID is provided
+		fmt.Println("Usage: ./uploader -path <file_or_directory_path> -dest <remote_directory> -channelID <telegram_channel_id>")
+		return
+	}
 
     config, err := loadConfigFromEnv()
 


### PR DESCRIPTION
As mentioned in #7 I was mainly trying to bring multiple channel support. Right now teldrive supports multi channel which is awesome but no way to upload to multiple channels. This can be done if the uploader supports channel id as a flag. then we can specify which channel to upload to. So I tried to add support for it. I tested the final release and it does include channel id but cant upload because teldrive rejects the payload. Just giving this in case it helps you out.

the final error that occurs is this 

` ./upload -path "/home/user/file" -dest "/file" -channelID "id"
file 100% [======================================================] (698 kB/s)Request failed with status code: 400
Error uploading file: HTTP error 400 (400 Bad Request) returned body: "{\"error\":\"invalid request payload\"}"
Uploads complete!`