### PR TITLE
Print error only if it's different from nil

### DIFF
--- a/main.go
+++ b/main.go
@@ -456,7 +456,9 @@ func (u *Uploader) uploadFilesInDirectory(sourcePath string, destDir string) err
 				Error.Fatalln(err)
 			}
 			err = u.uploadFilesInDirectory(fullPath, subDir)
-			Error.Println(err)
+			if err != nil {
+				Error.Println(err)
+			}
 		} else {
 
 			exists := u.checkFileExists(entry.Name(), files)


### PR DESCRIPTION
Hi, when uploading folders inside other folders, even when there's no error, it still prints `nil` as an error. This change checks if the error is not `nil` before printing it